### PR TITLE
[feature] atoms-inputの作成

### DIFF
--- a/src/components/atoms/input/index.stories.tsx
+++ b/src/components/atoms/input/index.stories.tsx
@@ -14,7 +14,7 @@ type InputValues = {
   example: string;
 };
 
-export const Template: ComponentStory<typeof Input> = () => {
+export const InputType: ComponentStory<typeof Input> = () => {
   const { register } = useForm<InputValues>();
   return (
     <Input
@@ -79,4 +79,5 @@ const DummyText = styled.div`
   width: 411px;
   font-size: 16px;
   line-height: 24px;
+  display: none;
 `;

--- a/src/components/atoms/input/index.stories.tsx
+++ b/src/components/atoms/input/index.stories.tsx
@@ -79,5 +79,10 @@ const DummyText = styled.div`
   width: 411px;
   font-size: 16px;
   line-height: 24px;
-  display: none;
+  opacity: 0;
+  position: absolute;
+  right: 520px;
+  border: solid 5px black;
+  padding: 2px 14px;
+  white-space: pre-wrap;
 `;

--- a/src/components/atoms/input/index.stories.tsx
+++ b/src/components/atoms/input/index.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta } from "@storybook/react";
+import { ComponentStory } from "@storybook/react";
+import { Input } from ".";
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import styled from "styled-components";
+
+export default {
+  title: "Atoms/Input",
+  component: Input,
+} as Meta;
+
+type InputValues = {
+  example: string;
+};
+
+export const Template: ComponentStory<typeof Input> = () => {
+  const { register } = useForm<InputValues>();
+  return (
+    <Input
+      type={"input"}
+      title="タイトル"
+      defaultValue="defaultValue"
+      placeholder="プレースホルダー"
+      register={register}
+      label="example"
+    />
+  );
+};
+
+export const TextareaType: ComponentStory<typeof Input> = () => {
+  const dummytextRef = useRef<HTMLParagraphElement>(null);
+  const { register, watch } = useForm<InputValues>();
+  const [height, setHeight] = useState<number>(0);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!dummytextRef.current) {
+      return;
+    }
+    const getTextAreaLineHeight = Number(
+      window
+        .getComputedStyle(dummytextRef.current)
+        .getPropertyValue("line-height")
+        .slice(0, 2)
+    );
+    const height =
+      watch("example").search(/\r?\n$/) == -1
+        ? dummytextRef.current.clientHeight
+        : dummytextRef.current.clientHeight + getTextAreaLineHeight;
+    setHeight(height);
+    console.log(height);
+
+    let ArrayText = Array.from(watch("example"));
+    ArrayText = ArrayText.filter((value) => {
+      return ![" ", "　", "\n"].includes(value);
+    });
+
+    const count = ArrayText.length;
+    setCount(count);
+  }, [watch("example")]);
+
+  return (
+    <>
+      <Input
+        countNumber={count}
+        height={height}
+        type={"textarea"}
+        register={register}
+        label="example"
+        title="タイトル"
+        placeholder="placeholder"
+      />
+      <DummyText ref={dummytextRef}>{watch("example")}</DummyText>
+    </>
+  );
+};
+const DummyText = styled.div`
+  width: 411px;
+  font-size: 16px;
+  line-height: 24px;
+`;

--- a/src/components/atoms/input/index.tsx
+++ b/src/components/atoms/input/index.tsx
@@ -1,0 +1,58 @@
+import {
+  CountText,
+  InputWrapper,
+  StyledInput,
+  StyledTextarea,
+  TitleText,
+  TitleWrapper,
+} from "./style";
+
+type InputProps = {
+  placeholder?: string;
+  title?: string;
+  defaultValue?: string;
+  countNumber?: number;
+  type: "input" | "textarea";
+  width?: number;
+  height?: number;
+  register: any;
+  label: any;
+};
+
+export const Input = ({
+  placeholder,
+  title,
+  defaultValue,
+  countNumber,
+  type,
+  width,
+  height,
+  register,
+  label,
+}: InputProps) => {
+  return (
+    <InputWrapper type={type}>
+      <TitleWrapper>
+        {title && <TitleText>{title}</TitleText>}
+        {countNumber ? <CountText>{countNumber}字</CountText> : null}
+      </TitleWrapper>
+      {type === "input" ? (
+        <StyledInput
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          inputWidth={width}
+          inputHeight={height}
+          {...register(label)}
+        />
+      ) : (
+        <StyledTextarea
+          placeholder={placeholder}
+          defaultValue={defaultValue}
+          inputWidth={width}
+          inputHeight={height}
+          {...register(label)}
+        />
+      )}
+    </InputWrapper>
+  );
+};

--- a/src/components/atoms/input/style.tsx
+++ b/src/components/atoms/input/style.tsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+
+export const TitleText = styled.span`
+  color: #052d93;
+  font-size: 24px;
+  font-weight: bold;
+`;
+export const InputWrapper = styled.div<{ type: "input" | "textarea" }>`
+  width: ${({ type }) => type === "textarea" && "fit-content"};
+`;
+export const StyledInput = styled.input<{
+  inputWidth?: number;
+  inputHeight?: number;
+}>`
+  width: ${({ inputWidth }) => (inputWidth ? `${inputWidth}px` : "100%")};
+  height: ${({ inputHeight }) => inputHeight}px;
+  min-height: 24px;
+  padding: 10px 20px;
+  font-size: 16px;
+  border: solid 5px #052d93;
+  outline: none;
+  border-radius: 12px;
+  &::placeholder {
+    color: #818181;
+    font-size: 16px;
+  }
+`;
+export const StyledTextarea = styled.textarea<{
+  inputWidth?: number;
+  inputHeight?: number;
+}>`
+  width: ${({ inputWidth }) => inputWidth}px;
+  height: ${({ inputHeight }) => inputHeight}px;
+  min-height: 96px;
+  min-width: 411px;
+  padding: 10px 20px;
+  font-size: 16px;
+  line-height: 24px;
+  resize: none;
+  border: solid 5px #052d93;
+  border-radius: 12px;
+  outline: none;
+  &::placeholder {
+    color: #818181;
+    font-size: 16px;
+  }
+`;
+export const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+`;
+export const CountText = styled.p`
+  color: #959595;
+  font-size: 20px;
+  margin: 0;
+`;


### PR DESCRIPTION
・文字数カウントや縦幅調整はreact-hook-formのwatchを使いたいため親要素で実装する（実装サンプルはstoriesファイルに書いた）
・registerとlabelの型について、このコンポーネントは様々な場面で使うため特定のフォーム名で指定したくなかったのでanyにしてる。より良い実装方法があればリファクタ対象（とりあえず機能優先させてるのでこれでPR出しました、致命的であれば直します）。